### PR TITLE
Create volumeicon

### DIFF
--- a/gui-extra/volumeicon
+++ b/gui-extra/volumeicon
@@ -1,0 +1,20 @@
+# Depends on: gtk3 alsa-lib libnotify
+
+description="Volume control for your system tray"
+url="http://softwarebakery.com/maato/volumeicon.html"
+packager="SipoMatadorduCosmos"
+
+name=volumeicon
+version=0.5.1
+release=1
+
+source=(https://github.com/Maato/volumeicon/archive/$version.tar.gz)
+
+
+build() {
+  cd $name-$version
+  ./autogen.sh
+  ./configure --prefix=/usr --enable-notify
+  make
+  make DESTDIR=$PKG install
+}


### PR DESCRIPTION
Un petit potentiomètre de volume idéal pour Tint2 et Openbox (à exécuter dans le /.config/openbox/autostart.sh